### PR TITLE
Fixed SyntaxError

### DIFF
--- a/bin/git-browse-remote
+++ b/bin/git-browse-remote
@@ -115,5 +115,5 @@ path = Path.new(path)
 template = `git config --get browse-remote.#{host}.#{mode}`[/.+/] or
     abort "No '#{mode}' mapping found for #{host} (maybe `git browse-remote --init` required)"
 
-url = template.gsub(/{(.+?)}/) { |m| eval($1) }
+url = template.gsub(/\{(.+?)\}/) { |m| eval($1) }
 exec 'git', 'web--browse', url


### PR DESCRIPTION
my ruby learn is no good, but a possible fix it.
- errors

```
$ gem install git-browse-remote
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions into the /Library/Ruby/Gems/1.8 directory.
exit 1
```

```
$ sudo gem install git-browse-remote
dyld: DYLD_ environment variables being ignored because main executable (/usr/bin/sudo) is setuid or setgid
Password:
Successfully installed git-browse-remote-0.0.1
1 gem installed
Installing ri documentation for git-browse-remote-0.0.1...
File not found: lib
exit 1
```

```
$ git browse-remote --init
/usr/bin/git-browse-remote:19:in `load': /Library/Ruby/Gems/1.8/gems/git-browse-remote-0.0.1/bin/git-browse-remote:118: invalid regular expression; there's no previous pattern, to which '{' would define cardinality at 1: /{(.+?)}/ (SyntaxError)
        from /usr/bin/git-browse-remote:19
exit 1
```

```
$ git browse-remote 
/usr/bin/git-browse-remote:19:in `load': /Library/Ruby/Gems/1.8/gems/git-browse-remote-0.0.1/bin/git-browse-remote:118: invalid regular expression; there's no previous pattern, to which '{' would define cardinality at 1: /{(.+?)}/ (SyntaxError)
        from /usr/bin/git-browse-remote:19
exit 1
```
- after my patched

```
$ git browse-remote --init
Writing config for github.com...
Mappings generated:
browse-remote.github.com.top https://{host}/{path}
browse-remote.github.com.ref https://{host}/{path}/tree/{short_ref}
browse-remote.github.com.rev https://{host}/{path}/commit/{commit}
$ git browse-remote
```
- my env on Macbook Air 2012

```
$ ruby --version
ruby 1.8.7 (2012-02-08 patchlevel 358) [universal-darwin12.0]
```

```
$ gem --version
1.3.6
```
