### PR TITLE
Replace File.exists? to File.exist?

### DIFF
--- a/lib/git/browse/remote/core.rb
+++ b/lib/git/browse/remote/core.rb
@@ -52,11 +52,11 @@ module Git::Browse::Remote
     end
 
     def url
-      if target && !@file && File.exists?(target)
+      if target && !@file && File.exist?(target)
         self.target, @file = nil, target
       end
 
-      if @file && File.exists?(@file)
+      if @file && File.exist?(@file)
         @file = Filepath.new(@file)
       end
 


### PR DESCRIPTION
On Ruby 3.2.0, git-browse-remote raises NoMethodError:

```
.../lib/ruby/gems/3.2.0/gems/git-browse-remote-0.2.0/lib/git/browse/remote/core.rb:55:in `url': undefined method `exists?' for File:Class (NoMethodError)
```

`File.exists?` method is deprecated since 2.1.0 and removed in 3.2.0 in favor of alternative method `File.exist?`.

https://bugs.ruby-lang.org/issues/17391